### PR TITLE
Update mod_jhu_death_rate.R

### DIFF
--- a/R/mod_jhu_death_rate.R
+++ b/R/mod_jhu_death_rate.R
@@ -19,7 +19,7 @@ mod_jhu_death_rate_ui <- function(id){
     id = ns("card"),
     title = "Death Rate",
     echarts4r::echarts4rOutput(ns("trend"), height = 385),
-    footer = "Confirmed / deaths"
+    footer = "Resolved cases (death or recovery) / deaths"
   )
 }
     
@@ -54,7 +54,7 @@ mod_jhu_death_rate_server <- function(input, output, session, df){
         )
       ) %>%
       dplyr::mutate(
-        rate = death / confirmed,
+        rate = deadCount / (deadCount + curedCount), # I'm making the change based on mod_dxy_table.R but I'm not 100% sure of the names of the variables
         rate = round(rate * 100, 3)
       ) %>% 
       echarts4r::e_charts(date2) %>% 


### PR DESCRIPTION
That formula (death/diagnosed) underestimates the correct case fatality rate: "The CFR number during the course of an outbreak with a high daily increase and long resolution time would be substantially lower than the final CFR" in https://en.wikipedia.org/wiki/Case_fatality_rate. 

Some people propose to do the ratio on "resolved cases" - that is all cases that have resolved (death or recovery) to minimize the risk of underestimation due to the fact that some of the cases in progress will result, unfortunately, in a fatality.